### PR TITLE
refactor normalize_document for simplicity

### DIFF
--- a/recall/dpr/getemb.py
+++ b/recall/dpr/getemb.py
@@ -29,11 +29,7 @@ def build_passage_text(doc: dict):
 
 def normalize_document(document: str):
     document = document.replace("\n", " ").replace("’", "'")
-    if document.startswith('"'):
-        document = document[1:]
-    if document.endswith('"'):
-        document = document[:-1]
-    return document
+    return document.strip('"')
     
 def generate_embeddings(args):
     distributed_state = PartialState()


### PR DESCRIPTION
The current implementation of `normalize_document` manually checks and strips quotes, which is verbose.  
We can replace it with `str.strip('"')` to keep the same behavior while making the code cleaner.
